### PR TITLE
Reform Kubernetes

### DIFF
--- a/plugin.yaml
+++ b/plugin.yaml
@@ -121,7 +121,8 @@ node_types:
   cloudify.mist.nodes.KeyPair:
     derived_from: cloudify.nodes.Root
     properties:
-      install_agent: false
+      install_agent: 
+        default: false
       use_external_resource:
         description: >
           Indicate whether the resource exists or if Cloudify should create the resource.
@@ -163,7 +164,8 @@ node_types:
   cloudify.mist.nodes.Server:
     derived_from: cloudify.nodes.Compute
     properties:
-      install_agent: false
+      install_agent:
+        default: false
       use_external_resource:
         description: >
           Indicate whether the resource exists or if Cloudify should create the resource.
@@ -221,7 +223,8 @@ node_types:
   cloudify.mist.nodes.Network:
     derived_from: cloudify.nodes.Network
     properties:
-      install_agent: false
+      install_agent:
+        default: false
       use_external_resource:
         description: >
           Indicate whether the resource exists or if Cloudify should create the resource.

--- a/plugin.yaml
+++ b/plugin.yaml
@@ -121,8 +121,8 @@ node_types:
   cloudify.mist.nodes.KeyPair:
     derived_from: cloudify.nodes.Root
     properties:
-      install_agent: 
-        default: false
+#      install_agent: 
+#        default: false
       use_external_resource:
         description: >
           Indicate whether the resource exists or if Cloudify should create the resource.
@@ -164,8 +164,8 @@ node_types:
   cloudify.mist.nodes.Server:
     derived_from: cloudify.nodes.Compute
     properties:
-      install_agent:
-        default: false
+#      install_agent:
+#        default: false
       use_external_resource:
         description: >
           Indicate whether the resource exists or if Cloudify should create the resource.
@@ -223,8 +223,8 @@ node_types:
   cloudify.mist.nodes.Network:
     derived_from: cloudify.nodes.Network
     properties:
-      install_agent:
-        default: false
+#      install_agent:
+#        default: false
       use_external_resource:
         description: >
           Indicate whether the resource exists or if Cloudify should create the resource.

--- a/plugin.yaml
+++ b/plugin.yaml
@@ -121,7 +121,7 @@ node_types:
   cloudify.mist.nodes.KeyPair:
     derived_from: cloudify.nodes.Root
     properties:
-#      install_agent: 
+#      install_agent:
 #        default: false
       use_external_resource:
         description: >

--- a/plugin.yaml
+++ b/plugin.yaml
@@ -1,9 +1,9 @@
 tosca_definitions_version: cloudify_dsl_1_2
 
 plugins:
-    mist:
-      executor: central_deployment_agent
-      source: "https://github.com/mistio/cloudify-mist-plugin/archive/master.zip"
+  mist:
+    executor: central_deployment_agent
+    source: "https://github.com/mistio/cloudify-mist-plugin/archive/master.zip"
 
 data_types:
   cloudify.datatypes.mist.Config:
@@ -158,7 +158,6 @@ node_types:
       cloudify.interfaces.validation:
         creation: mist.plugin.keypair.creation_validation
 
-
   cloudify.mist.nodes.Server:
     derived_from: cloudify.nodes.Compute
     properties:
@@ -216,7 +215,6 @@ node_types:
             args:
               default: {}
 
-
   cloudify.mist.nodes.Network:
     derived_from: cloudify.nodes.Network
     properties:
@@ -251,98 +249,102 @@ node_types:
         delete:
           implementation: mist.plugin.network.delete
 
+###
+### DEPRACATED: Moved to the new Kubernetes blueprint
+###
+#  cloudify.mist.nodes.KubernetesMaster:
+#    derived_from: cloudify.mist.nodes.Server
+#    properties:
+#      use_external_resource:
+#        description: >
+#          Indicate whether the resource exists or if Cloudify should create the resource.
+#        type: boolean
+#        default: false
+#      configured:
+#        description: Indicate whether kubernetes is configured
+#        type: boolean
+#        default: false
+#      resource_id:
+#        description: >
+#          Either the name or ID of the resource in Cloudify. If this is an existing
+#          resource, you should provide the name or the ID of the resource in Mist.io.
+#        type: string
+#        default: ''
+#      coreos:
+#        type: boolean
+#        default: false
+#      parameters:
+#        description: >
+#          The key value pair parameters required by Mist Client to use
+#          the mist.client.backend.create_machine command.(backend_id,image_id
+#          size_id, location_id, name, monitoring, ssh_user, networks )
+#        type: cloudify.datatypes.mist.MachineParams
+#      mist_config:
+#        description: >
+#          A dictionary of values to pass to authenticate with the Mist API.
+#        type: cloudify.datatypes.mist.Config
+#    interfaces:
+#      cloudify.interfaces.lifecycle:
+#        configure:
+#          implementation: mist.plugin.kubernetes.install_kubernetes
+#          inputs:
+#            master:
+#              type: boolean
+#              default: true
+#            start_retry_interval:
+#              description: Polling interval until the server is active in seconds
+#              type: integer
+#              default: 30
 
-  cloudify.mist.nodes.KubernetesMaster:
-    derived_from: cloudify.mist.nodes.Server
-    properties:
-      use_external_resource:
-        description: >
-          Indicate whether the resource exists or if Cloudify should create the resource.
-        type: boolean
-        default: false
-      configured:
-        description: Indicate whether kubernetes is configured
-        type: boolean
-        default: false
-      resource_id:
-        description: >
-          Either the name or ID of the resource in Cloudify. If this is an existing
-          resource, you should provide the name or the ID of the resource in Mist.io.
-        type: string
-        default: ''
-      coreos:
-        type: boolean
-        default: false
-      parameters:
-        description: >
-          The key value pair parameters required by Mist Client to use
-          the mist.client.backend.create_machine command.(backend_id,image_id
-          size_id, location_id, name, monitoring, ssh_user, networks )
-        type: cloudify.datatypes.mist.MachineParams
-      mist_config:
-        description: >
-          A dictionary of values to pass to authenticate with the Mist API.
-        type: cloudify.datatypes.mist.Config
-    interfaces:
-      cloudify.interfaces.lifecycle:
-        configure:
-          implementation: mist.plugin.kubernetes.install_kubernetes
-          inputs:
-            master:
-              type: boolean
-              default: true
-            start_retry_interval:
-              description: Polling interval until the server is active in seconds
-              type: integer
-              default: 30
+###
+### DEPRACATED: Moved to the new Kubernetes blueprint
+###
+#  cloudify.mist.nodes.KubernetesWorker:
+#    derived_from: cloudify.mist.nodes.Server
+#    properties:
+#      use_external_resource:
+#        description: >
+#          Indicate whether the resource exists or if Cloudify should create the resource.
+#        type: boolean
+#        default: false
+#      configured:
+#        description: Indicate whether kubernetes is configured
+#        type: boolean
+#        default: false
+#      resource_id:
+#        description: >
+#          Either the name or ID of the resource in Cloudify. If this is an existing
+#          resource, you should provide the name or the ID of the resource in Mist.io.
+#        type: string
+#        default: ''
+#      parameters:
+#        description: >
+#          The key value pair parameters required by Mist Client to use
+#          the mist.client.backend.create_machine command.(backend_id,image_id
+#          size_id, location_id, name, monitoring, ssh_user, networks )
+#        default: {}
+#      coreos:
+#        description: Whether it's a coreos image or not
+#        type: boolean
+#        default: false
+#      mist_config:
+#        description: >
+#          A dictionary of values to pass to authenticate with the Mist API.
+#        default: {}
+#    interfaces:
+#      cloudify.interfaces.lifecycle:
+#        configure:
+#          implementation: mist.plugin.kubernetes.install_kubernetes
+#          inputs:
+#            master:
+#              type: boolean
+#              default: false
+#            start_retry_interval:
+#              description: Polling interval until the server is active in seconds
+#              type: integer
+#              default: 30
 
-
-
-  cloudify.mist.nodes.KubernetesWorker:
-    derived_from: cloudify.mist.nodes.Server
-    properties:
-      use_external_resource:
-        description: >
-          Indicate whether the resource exists or if Cloudify should create the resource.
-        type: boolean
-        default: false
-      configured:
-        description: Indicate whether kubernetes is configured
-        type: boolean
-        default: false
-      resource_id:
-        description: >
-          Either the name or ID of the resource in Cloudify. If this is an existing
-          resource, you should provide the name or the ID of the resource in Mist.io.
-        type: string
-        default: ''
-      parameters:
-        description: >
-          The key value pair parameters required by Mist Client to use
-          the mist.client.backend.create_machine command.(backend_id,image_id
-          size_id, location_id, name, monitoring, ssh_user, networks )
-        default: {}
-      coreos:
-        description: Whether it's a coreos image or not
-        type: boolean
-        default: false
-      mist_config:
-        description: >
-          A dictionary of values to pass to authenticate with the Mist API.
-        default: {}
-    interfaces:
-      cloudify.interfaces.lifecycle:
-        configure:
-          implementation: mist.plugin.kubernetes.install_kubernetes
-          inputs:
-            master:
-              type: boolean
-              default: false
-            start_retry_interval:
-              description: Polling interval until the server is active in seconds
-              type: integer
-              default: 30
-
+# TODO: relationship to connect worker to master
 
 relationships:
   cloudify.mist.relationships.server_connected_to_keypair:

--- a/plugin.yaml
+++ b/plugin.yaml
@@ -120,6 +120,7 @@ node_types:
   cloudify.mist.nodes.KeyPair:
     derived_from: cloudify.nodes.Root
     properties:
+      install_agent: false
       use_external_resource:
         description: >
           Indicate whether the resource exists or if Cloudify should create the resource.
@@ -161,6 +162,7 @@ node_types:
   cloudify.mist.nodes.Server:
     derived_from: cloudify.nodes.Compute
     properties:
+      install_agent: false
       use_external_resource:
         description: >
           Indicate whether the resource exists or if Cloudify should create the resource.
@@ -218,6 +220,7 @@ node_types:
   cloudify.mist.nodes.Network:
     derived_from: cloudify.nodes.Network
     properties:
+      install_agent: false
       use_external_resource:
         description: >
           Indicate whether the resource exists or if Cloudify should create the resource.

--- a/plugin.yaml
+++ b/plugin.yaml
@@ -121,8 +121,8 @@ node_types:
   cloudify.mist.nodes.KeyPair:
     derived_from: cloudify.nodes.Root
     properties:
-#      install_agent:
-#        default: false
+      install_agent:
+        default: false
       use_external_resource:
         description: >
           Indicate whether the resource exists or if Cloudify should create the resource.
@@ -164,8 +164,8 @@ node_types:
   cloudify.mist.nodes.Server:
     derived_from: cloudify.nodes.Compute
     properties:
-#      install_agent:
-#        default: false
+      install_agent:
+        default: false
       use_external_resource:
         description: >
           Indicate whether the resource exists or if Cloudify should create the resource.
@@ -223,8 +223,8 @@ node_types:
   cloudify.mist.nodes.Network:
     derived_from: cloudify.nodes.Network
     properties:
-#      install_agent:
-#        default: false
+      install_agent:
+        default: false
       use_external_resource:
         description: >
           Indicate whether the resource exists or if Cloudify should create the resource.

--- a/plugin.yaml
+++ b/plugin.yaml
@@ -3,7 +3,8 @@ tosca_definitions_version: cloudify_dsl_1_2
 plugins:
   mist:
     executor: central_deployment_agent
-    source: "https://github.com/mistio/cloudify-mist-plugin/archive/master.zip"
+    # FIXME
+    source: "https://github.com/mistio/cloudify-mist-plugin/archive/reform_kube.zip"
 
 data_types:
   cloudify.datatypes.mist.Config:

--- a/plugin.yaml
+++ b/plugin.yaml
@@ -221,7 +221,6 @@ node_types:
   cloudify.mist.nodes.Network:
     derived_from: cloudify.nodes.Network
     properties:
-      install_agent: false
       use_external_resource:
         description: >
           Indicate whether the resource exists or if Cloudify should create the resource.

--- a/plugin.yaml
+++ b/plugin.yaml
@@ -1,4 +1,4 @@
-tosca_definitions_version: cloudify_dsl_1_2
+tosca_definitions_version: cloudify_dsl_1_3
 
 plugins:
   mist:

--- a/setup.py
+++ b/setup.py
@@ -12,13 +12,13 @@ setup(
     zip_safe=False,
     install_requires=[
         # Necessary dependency for developing plugins, do not remove!
-        'cloudify-plugins-common>=3.3a5',
+        'cloudify-plugins-common==3.4.1',
     ],
     dependency_links=[
         'https://github.com/mistio/mist.client/archive/master.zip',
     ],
     test_requires=[
-        'cloudify-dsl-parser>=3.3a5',
+        'cloudify-dsl-parser==3.4.1',
         'nose',
     ]
 )

--- a/setup.py
+++ b/setup.py
@@ -12,13 +12,13 @@ setup(
     zip_safe=False,
     install_requires=[
         # Necessary dependency for developing plugins, do not remove!
-        'cloudify-plugins-common==3.4.1',
+        'cloudify-plugins-common==3.4',
     ],
     dependency_links=[
         'https://github.com/mistio/mist.client/archive/master.zip',
     ],
     test_requires=[
-        'cloudify-dsl-parser==3.4.1',
+        'cloudify-dsl-parser==3.4',
         'nose',
     ]
 )

--- a/setup.py
+++ b/setup.py
@@ -3,7 +3,7 @@ from setuptools import setup
 
 setup(
     name='cloudify-mist-plugin',
-    version='0.0.9',
+    version='0.0.10',
     author='mist',
     author_email='info@mist.io',
     description='Cloudify plugin for Mist infrastructure.',


### PR DESCRIPTION
- Bump up versions
- Move install_agent property to the plugin (initially part of the blueprint)
- Deprecate cloudify.mist.nodes.KubernetesMaster & cloudify.mist.nodes.KubernetesWorker (these have been moved to the kubernetes-blueprint)
- Improve server.py operations
- Improve kubernetes.py workflows & fix kubernetes master API call
